### PR TITLE
CI: uninstall q2galaxy before dev install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
         source "$CONDA/etc/profile.d/conda.sh"
         conda activate ../test-env
         pip install planemo
+        conda uninstall -y q2galaxy
         make dev
 
     - name: template all


### PR DESCRIPTION
There seems to be a trailing `.pth` file that conda will clean up, but pip is unaware of until it notices it somewhere through the install process.