### PR TITLE
MAINT: filter jobs and threads primitives from xml

### DIFF
--- a/q2galaxy/core/templaters/helpers.py
+++ b/q2galaxy/core/templaters/helpers.py
@@ -8,7 +8,7 @@
 import os
 import itertools
 from qiime2.sdk.util import (interrogate_collection_type, is_semantic_type,
-                             is_union, is_metadata_type,
+                             is_union, is_metadata_type, is_parallel_type,
                              is_metadata_column_type)
 from qiime2.plugin import Choices
 from qiime2.core.type.signature import ParameterSpec
@@ -43,6 +43,8 @@ def identify_arg_case(name, spec, arg, data_dir=None):
     if is_semantic_type(spec.qiime_type):
         return InputCase(name, spec, arg, data_dir=data_dir,
                          multiple=style.style is not None)
+    elif is_parallel_type(spec.qiime_type):
+        return None
 
     if style.style is None:  # not a collection
         if is_union_anywhere(spec.qiime_type):
@@ -56,9 +58,6 @@ def identify_arg_case(name, spec, arg, data_dir=None):
             return BoolCase(name, spec, arg)
         elif spec.qiime_type.name == 'Str':
             return StrCase(name, spec, arg)
-        elif spec.qiime_type.name in ('Jobs', 'Threads'):
-            # we don't want these to be forwarded to galaxy
-            return None
         else:
             return NumericCase(name, spec, arg)
 

--- a/q2galaxy/core/templaters/helpers.py
+++ b/q2galaxy/core/templaters/helpers.py
@@ -26,7 +26,10 @@ def signature_to_galaxy(signature, arguments=None, data_dir=None):
             continue
         else:
             arg = arguments[name]
-        yield identify_arg_case(name, spec, arg, data_dir=data_dir)
+
+        arg = identify_arg_case(name, spec, arg, data_dir=data_dir)
+        if arg is not None:
+            yield arg
 
 
 def is_union_anywhere(qiime_type):
@@ -53,6 +56,9 @@ def identify_arg_case(name, spec, arg, data_dir=None):
             return BoolCase(name, spec, arg)
         elif spec.qiime_type.name == 'Str':
             return StrCase(name, spec, arg)
+        elif spec.qiime_type.name in ('Jobs', 'Threads'):
+            # we don't want these to be forwarded to galaxy
+            return None
         else:
             return NumericCase(name, spec, arg)
 


### PR DESCRIPTION
Don't pass along parameters of type Jobs or Threads (see qiime2/qiime2#745)
