### PR TITLE
Add xrefs with bio.tools to XMLs

### DIFF
--- a/q2galaxy/core/templaters/action.py
+++ b/q2galaxy/core/templaters/action.py
@@ -14,7 +14,7 @@ from q2galaxy.core.usage import GalaxyTestUsage
 from q2galaxy.core.util import XMLNode, galaxy_ui_var, rst_header
 from q2galaxy.core.templaters.common import (
     make_tool_id, make_tool_name, make_config, make_citations,
-    make_requirements)
+    make_requirements, make_xrefs)
 from q2galaxy.core.templaters.helpers import signature_to_galaxy
 
 
@@ -76,6 +76,7 @@ def make_tool(conda_meta, plugin, action, test_dir):
     tool.append(make_help(plugin, action, test_dir))
     tool.append(make_citations(plugin, action))
     tool.append(make_requirements(conda_meta, plugin.project_name))
+    tool.append(make_xrefs())
     return tool
 
 

--- a/q2galaxy/core/templaters/common.py
+++ b/q2galaxy/core/templaters/common.py
@@ -115,3 +115,10 @@ def make_formats_help(formats):
             help_ += f' - {format_.__name__}\n'
 
     return help_
+
+
+def make_xrefs():
+    xefs = XMLNode('xefs')
+    xefs.append(
+        XMLNode('xref', 'qiime2', type='bio.tools'))
+    return xefs

--- a/q2galaxy/core/templaters/common.py
+++ b/q2galaxy/core/templaters/common.py
@@ -118,7 +118,7 @@ def make_formats_help(formats):
 
 
 def make_xrefs():
-    xefs = XMLNode('xefs')
-    xefs.append(
+    xrefs = XMLNode('xrefs')
+    xrefs.append(
         XMLNode('xref', 'qiime2', type='bio.tools'))
-    return xefs
+    return xrefs

--- a/q2galaxy/core/templaters/export_data.py
+++ b/q2galaxy/core/templaters/export_data.py
@@ -12,7 +12,7 @@ from qiime2.sdk.plugin_manager import GetFormatFilters
 from q2galaxy.core.util import XMLNode, galaxy_esc, pretty_fmt_name, rst_header
 from q2galaxy.core.templaters.common import (
     make_builtin_version, make_requirements, make_tool_name_from_id,
-    make_config, make_citations, make_formats_help)
+    make_config, make_citations, make_formats_help, make_xrefs)
 
 
 def make_builtin_export(meta, tool_id):
@@ -170,6 +170,7 @@ def make_builtin_export(meta, tool_id):
     tool.append(make_citations())
     tool.append(make_requirements(meta, *[p.project_name for p in plugins]))
     tool.append(_make_help(known_formats))
+    tool.append(make_xrefs())
 
     return tool
 

--- a/q2galaxy/core/templaters/import_data.py
+++ b/q2galaxy/core/templaters/import_data.py
@@ -17,7 +17,8 @@ from q2galaxy.core.templaters.common import (make_builtin_version,
                                              make_tool_name_from_id,
                                              make_requirements,
                                              make_citations,
-                                             make_formats_help)
+                                             make_formats_help,
+                                             make_xrefs)
 
 
 def make_builtin_import(meta, tool_id):
@@ -110,6 +111,7 @@ def make_builtin_import(meta, tool_id):
     tool.append(make_citations())
     tool.append(make_requirements(meta, *[p.project_name for p in plugins]))
     tool.append(_make_help(known_formats))
+    tool.append(make_xrefs())
     return tool
 
 

--- a/q2galaxy/core/templaters/import_fastq_data.py
+++ b/q2galaxy/core/templaters/import_fastq_data.py
@@ -11,7 +11,8 @@ from q2galaxy.core.util import XMLNode
 from q2galaxy.core.templaters.common import (make_builtin_version,
                                              make_tool_name_from_id,
                                              make_requirements,
-                                             make_citations)
+                                             make_citations,
+                                             make_xrefs)
 
 
 def make_builtin_import_fastq(meta, tool_id):
@@ -33,6 +34,7 @@ def make_builtin_import_fastq(meta, tool_id):
     tool.append(_make_config())
     tool.append(make_citations())
     tool.append(make_requirements(meta, *[p.project_name for p in plugins]))
+    tool.append(make_xrefs())
     return tool
 
 

--- a/q2galaxy/core/util.py
+++ b/q2galaxy/core/util.py
@@ -18,10 +18,10 @@ import q2galaxy
 
 class OrderedTool(collections.OrderedDict):
     order = ["description", "macros", "edam_topics", "edam_operations",
-             "parallelism", "requirements", "code", "stdio", "version_command",
-             "command", "environment_variables", "configfiles", "inputs",
-             "request_param_translation", "outputs", "tests", "help",
-             "citations"]
+             "parallelism", "xrefs", "requirements", "code", "stdio",
+             "version_command", "command", "environment_variables",
+             "configfiles", "inputs", "request_param_translation",
+             "outputs", "tests", "help", "citations"]
     order_attr = ['name', 'argument', 'type', 'format', 'min', 'truevalue',
                   'max', 'falsevalue', 'value', 'checked', 'optional', 'label',
                   'help']


### PR DESCRIPTION
Hi,

This PR adds xrefs to XMLs with link to QIIME2 bio.tools entry: https://bio.tools/qiime2
It will be useful to get EDAM ontology annotations for the tool directly from bio.tools, e.g. for grouping tools by topics for the
new Galaxy tool panel.

It is the first time I look at this code so I hope I did not break anything 😅

Bérénice